### PR TITLE
Install php soap extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN docker-php-ext-install \
   mcrypt \
   pdo_mysql \
   xsl \
-  zip
+  zip \
+  soap
 
 RUN curl -sS https://getcomposer.org/installer | \
     php -- \


### PR DESCRIPTION
Currently when running Magento 2 unit tests on this Docker image, we get the following error:

`Fatal error: Uncaught Error: Call to undefined method Mock_SoapClient_91073b3c::__setSoapHeaders() in /vendor/magento/module-payment/Gateway/Http/Client/Soap.php:70`

This is because the Soap ClientFactory can't create a SoapClient. The solution is to install the php soap extension.
