### PR TITLE
Sync user's id between host and container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM php:7.0.8-fpm
 MAINTAINER Mark Shust <mark.shust@mageinferno.com>
 
+# Setup User to match Host User, and give superuser permissions
+ARG USER_ID=1000
+RUN usermod -u ${USER_ID} -aG sudo www-data && echo 'www-data ALL=(ALL) NOPASSWD: ALL'
+
 RUN apt-get update \
   && apt-get install -y \
     cron \


### PR DESCRIPTION
Hello, the issue is that creating files with www-data user in a container makes them not editable on a host.
This will sync user id's and allow the www-data user's id to be configurable view environment variables in docker-compose file.
