### PR TITLE
Fix invalid environment variable dereference in php.ini

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Mage Inferno
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/conf/php.ini
+++ b/conf/php.ini
@@ -1,2 +1,2 @@
-memory_limit = PHP_MEMORY_LIMIT
+memory_limit = ${PHP_MEMORY_LIMIT}
 date.timezone = "UTC"


### PR DESCRIPTION
This pull request fixes a bug pertaining to the [memory_limit](http://php.net/manual/en/ini.core.php#ini.memory-limit) directive in **conf/php.ini**. It was incorrectly dereferencing the _PHP_MEMORY_LIMIT_ environment variable.

This bug causes the following error to appear when running any sizable PHP script:

``` text
Fatal error: Allowed memory size of 2097152 bytes exhausted
```

Related output from `php -i` before this change:

``` text
memory_limit => PHP_MEMORY_LIMIT => PHP_MEMORY_LIMIT
PHP_MEMORY_LIMIT => 2G
```

And after this change:

``` text
memory_limit => 2G => 2G
PHP_MEMORY_LIMIT => 2G
```

This change should remove the need to specify `-d memory_limit=2G` in [bin/mage-setup-raw](https://github.com/mageinferno/docker-magento2-php/blob/master/bin/mage-setup-raw).
