### PR TITLE
Support using magento from an existing tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Mark Shust <mark.shust@mageinferno.com>
 
 RUN apt-get update && apt-get install -y \
   cron \
+  git \
   libfreetype6-dev \
   libicu-dev \
   libjpeg62-turbo-dev \

--- a/bin/mage-setup-raw
+++ b/bin/mage-setup-raw
@@ -8,7 +8,21 @@ if [ -f ./app/etc/config.php ] || [ -f ./app/etc/env.php ]; then
   exit
 fi
 
-if [ "$M2SETUP_USE_ARCHIVE" = true ]; then
+if [ "$M2SETUP_USE_EXISTING_MAGENTO" = true ]; then
+  if [ ! -d ./app/code/Magento ]; then
+    echo "\$M2SETUP_USE_EXISTING_MAGENTO specified, but did not find app/code/Magento - aborting."
+    exit
+  fi
+  echo 'Using existing magento codebase.';
+  composer install 
+  if [ "$M2SETUP_USE_SAMPLE_DATA" = true ]; then
+    if [ ! -d magento2-sample-data ]; then
+        git clone https://github.com/magento/magento2-sample-data.git
+    fi
+    (cd magento2-sample-data/dev/tools && php -f build-sample-data.php -- --ce-source=/var/www/html)
+    (cd magento2-sample-data && find . -type d -exec chmod g+ws {} \; ) 
+  fi
+elif [ "$M2SETUP_USE_ARCHIVE" = true ]; then
   echo "Downloading and untarring archive..."
   if [ "$M2SETUP_USE_SAMPLE_DATA" = true ]; then
     curl -L http://pubfiles.nexcess.net/magento/ce-packages/magento2-with-samples-$M2SETUP_VERSION.tar.gz | tar xzf - -o -C .


### PR DESCRIPTION
This patch adds support for using an existing magento tree (i.e. a git tree) instead of downloading.

I am using this with https://github.com/mageinferno/magento2-docker-compose:

1. Git clone magento codebase to 'html'.
2. (optionally) , git clone magento2-sample-data to html/magento2-sample-data
3. Set docker-compose.override.yml to:

```
version: "3"

services:
  app:
    volumes: &appvolumes
      - ./html:/var/www/html

  phpfpm:
    volumes: *appvolumes

  setup:
    volumes: *appvolumes
    environment:
      - M2SETUP_USE_EXISTING_MAGENTO=true
```

4. Run `docker-compose run --rm setup` like usual.

If M2SETUP_USE_SAMPLE_DATA = true but html/magento2-sample-data does not exist, setup will automatically git clone it for you.

If you accept this pull request I would be happy to document this option in the mageinferno/magento2-docker-compose README.md (I will submit a PR).